### PR TITLE
Fix pip install command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use OpenAI to scan your code for security issues from the CLI. Bring your own Op
 # Install
 
 ```bash
-pip install https://github.com/latiotech/LAST.git
+pip install git+https://github.com/latiotech/LAST.git
 
 OPENAI_API_KEY=xxx LAST partial ./ 
 ```


### PR DESCRIPTION
## What does this do?

Changes the `pip install` command that installs directly from the repository from

```sh
pip install https://github.com/latiotech/LAST.git
```

to

```sh
pip install git+https://github.com/latiotech/LAST.git
```

## Why?

The existing command example fails to install:

```sh
# pip install https://github.com/latiotech/LAST.git
Collecting https://github.com/latiotech/LAST.git
  Downloading https://github.com/latiotech/LAST.git
     | 259.7 kB 1.4 MB/s 0:00:00
  ERROR: Cannot unpack file /tmp/pip-unpack-qup91uww/LAST.git (downloaded from /tmp/pip-req-build-i0j08a7e, content-type: text/html; charset=utf-8); cannot detect archive format
ERROR: Cannot determine archive format of /tmp/pip-req-build-i0j08a7e
```

`pip install git+https://github.com/latiotech/LAST.git` works as expected

```sh
# pip install git+https://github.com/latiotech/LAST.git
Collecting git+https://github.com/latiotech/LAST.git
  Cloning https://github.com/latiotech/LAST.git to /tmp/pip-req-build-_ggb_slm
  Running command git clone --filter=blob:none --quiet https://github.com/latiotech/LAST.git /tmp/pip-req-build-_ggb_slm
  Resolved https://github.com/latiotech/LAST.git to commit 50b3d6cb1af3f0b3390dd56ce47c38224982b155
  Preparing metadata (setup.py) ... done
Collecting openai==1.3.7 (from LAST==0.0.1)
...
```