### PR TITLE
fix: guard against empty choices and message=None in LLM responses

### DIFF
--- a/src/latio/core.py
+++ b/src/latio/core.py
@@ -213,6 +213,8 @@ def full_sec_scan(application_summary, model):
                 max_tokens=1000,
                 temperature=0.7,
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             message = response.choices[0].message.content.strip()
             return message
         except Exception as e:
@@ -241,6 +243,8 @@ def full_health_scan(application_summary, model):
                 max_tokens=1000,
                 temperature=0.7,
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             message = response.choices[0].message.content.strip()
             return message
         except Exception as e:
@@ -450,6 +454,8 @@ def partial_sec_scan(application_summary, model):
                 max_tokens=1000,
                 temperature=0.7,
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             message = response.choices[0].message.content.strip()
             return message
         except Exception as e:
@@ -478,6 +484,8 @@ def partial_health_scan(application_summary, model):
                 max_tokens=1000,
                 temperature=0.7,
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             message = response.choices[0].message.content.strip()
             return message
         except Exception as e:


### PR DESCRIPTION
## What

Add explicit guards at all four LLM call sites in `src/latio/core.py` before accessing `response.choices[0].message.content`.

## Why

`client.chat.completions.create()` can return two empty-response shapes:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures
2. **`choices[0].message = None`** — Gemini 2.5 Flash (via the OpenAI-compatible endpoint) returns HTTP 200 with `finish_reason: PROHIBITED_CONTENT` and `message=None`

Currently the `IndexError`/`AttributeError` is caught by the surrounding `except Exception as e: return f"Error occurred: {e}"`, which swallows the crash and returns an uninformative string. The explicit guard raises a `ValueError` with a clear message before `message.content` is accessed, so callers get a precise failure reason.

## Change

```python
# Before
message = response.choices[0].message.content.strip()

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
message = response.choices[0].message.content.strip()
```

Applied to all 4 call sites (security scan, health scan, full health scan, partial health scan).

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.7k violations in 786 repos.